### PR TITLE
docs: optional vendor attribute and added unit for daluren in lovelace examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ cards:
               name: Daluren
               attribute: offpeak_usage
               entity: ${'sensor.telenet_'+internet.identifier+'_internet_usage'}
+			  unit: GB
               icon: mdi:arrow-down-bold
         - type: custom:dual-gauge-card
           title: false
@@ -309,7 +310,7 @@ content: >
   |Name|IP|Interface|Vendor
   |----:|----:|----:|----:|{% for item in state_attr("sensor.telenet_<customer_id>_<identifier>_internet_network","clients") %}
   {%if "name" in item %}{{item["name"]}}{% else %}|{%-endif %}|{%for ip in item["ipAddressInfos"] %}{%if ip["ipType"] == "IPv4" %}{{ip["ipAddress"]}}{%-endif %}
-  {%-endfor %}|{{item["connectedInterface"]}}|{{item["vendor"]}}{%-endfor %}
+  {%-endfor %}|{{item["connectedInterface"]}}|{%if "vendor" in item %}{{item["vendor"]}}{% else %}|{%-endif %}{%-endfor %}
 
   ## Wifi Settings
   |||


### PR DESCRIPTION
Just discovered this in HACS. Awesome plugin, thank you!

Made some small changes for lovelace examples in the README.

### Description

2 changes in the README considering the lovelace examples:

1. In the network clients, my clients did not always had a "vendor" attribute causing the example to not work. So I changed the template code to display "vendor" if present, else "".
2. In the peak-usage example, the daluren example did not have a unit GB in the example code, while the screenshot does have it.

### Motivation and Context

Had an issue with copy pasting the example when setting up the plugin, might help others in the future.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [ ] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [x] **Docs** (changes that only update documentation)
- [x] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Screenshots (if appropriate):
